### PR TITLE
Add possibility to specify result bundle explicitly

### DIFF
--- a/Sources/Helpers.swift
+++ b/Sources/Helpers.swift
@@ -36,3 +36,8 @@ func shell(_ command: String, verbose: Bool) -> String {
     
     return output
 }
+
+enum Arguments {
+    case project(scheme: String, workspace: String?)
+    case resultBundle(path: String)
+}

--- a/Sources/Implementation.swift
+++ b/Sources/Implementation.swift
@@ -52,10 +52,18 @@ func getTestResult(using buildSettings: BuildSettings, verbose: Bool) throws -> 
     let testContents = (try? FileManager.default.contentsOfDirectory(at: testDir, includingPropertiesForKeys: nil)) ?? []
     
     guard let testResult = testContents.filter({ $0.absoluteString.contains("xcresult") }).first
-    else { throw ParserError.noTestResults }
+    else { throw ParserError.noTestResults(testDir.path) }
+    
+    return try getTestResult(from: testResult.path, verbose: verbose)
+}
+
+func getTestResult(from path: String, verbose: Bool) throws -> TestResult {
+    guard FileManager.default.fileExists(atPath: path) else {
+        throw ParserError.noTestResults(path)
+    }
     
     let testResultJSON = shell(
-        "xcrun xccov view --report --json \(testResult.path) 2>/dev/null",
+        "xcrun xccov view --report --json " + path + " 2>/dev/null",
         verbose: verbose
     )
     let data = Data(testResultJSON.utf8)

--- a/Sources/Models/ParserError.swift
+++ b/Sources/Models/ParserError.swift
@@ -11,6 +11,18 @@ enum ParserError: Error {
     case decoding(DecodingError)
     case noBuildDir
     case noWorkspace
-    case noTestResults
+    case noTestResults(String)
     case unknown(Error)
+}
+
+extension ParserError: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .decoding(let error): return error.localizedDescription
+        case .noBuildDir: return "Missing Build directory in DerivedData"
+        case .noWorkspace: return "No workspace can be found"
+        case .noTestResults(let path): return "No XCResult bundle can be found at '" + path + "'"
+        case .unknown(let error): return "Unknown error occured: " + error.localizedDescription
+        }
+    }
 }

--- a/Sources/Subcommands/ParseFromProject.swift
+++ b/Sources/Subcommands/ParseFromProject.swift
@@ -1,0 +1,24 @@
+import ArgumentParser
+
+struct ParseFromProject: ParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(commandName: "project")
+    }
+    
+    @Option(name: .long, help: "Name of the scheme")
+    var scheme: String
+
+    @Option(name: .long, help: "Name of the workspace")
+    var workspace: String?
+    
+    @Flag(help: "Set verbose output")
+    var verbose = false
+    
+    private var arguments: Arguments {
+        .project(scheme: scheme, workspace: workspace)
+    }
+    
+    func run() throws {
+        try getCoverage(using: arguments, verbose: verbose)
+    }
+}

--- a/Sources/Subcommands/ParseFromResultBundle.swift
+++ b/Sources/Subcommands/ParseFromResultBundle.swift
@@ -5,7 +5,7 @@ struct ParseFromResultBundle: ParsableCommand {
         CommandConfiguration(commandName: "bundle")
     }
     
-    @Option(name: .long, help: "")
+    @Option(name: .long, help: "Path of .xcresult bundle file to be parsed")
     var resultBundlePath: String
     
     @Flag(help: "Set verbose output")

--- a/Sources/Subcommands/ParseFromResultBundle.swift
+++ b/Sources/Subcommands/ParseFromResultBundle.swift
@@ -1,0 +1,20 @@
+import ArgumentParser
+
+struct ParseFromResultBundle: ParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(commandName: "bundle")
+    }
+    
+    @Option(name: .long, help: "")
+    var resultBundlePath: String
+    
+    @Flag(help: "Set verbose output")
+    var verbose = false
+    
+    func run() throws {
+        try getCoverage(
+            using: .resultBundle(path: resultBundlePath),
+            verbose: verbose
+        )
+    }
+}

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -9,17 +9,29 @@ import ArgumentParser
 
 struct TestCoverageParser: ParsableCommand {
     @Option(name: .long, help: "Name of the scheme")
-    var scheme: String
+    var scheme: String?
 
     @Option(name: .long, help: "Name of the workspace")
     var workspace: String?
+    
+    @Option(name: .long, help: "")
+    var resultBundlePath: String?
         
     @Flag(help: "Set verbose output")
     var verbose = false
     
     func run() throws {
-        let buildSettings = try getBuildSettings(workspace: workspace, scheme: scheme, verbose: verbose)
-        let result = try getTestResult(using: buildSettings, verbose: verbose)
+        let result: TestResult = try {
+            if let resultBundlePath = resultBundlePath {
+                return try getTestResult(from: resultBundlePath, verbose: verbose)
+            } else if let scheme = scheme {
+                let buildSettings = try getBuildSettings(workspace: workspace, scheme: scheme, verbose: verbose)
+                return try getTestResult(using: buildSettings, verbose: verbose)
+            } else {
+                throw ValidationError("One of arguments `--scheme` or `--result-bundle-path` is required")
+            }
+        }()
+        
         print(result.lineCoverage)
     }
 }

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -8,31 +8,14 @@
 import ArgumentParser
 
 struct TestCoverageParser: ParsableCommand {
-    @Option(name: .long, help: "Name of the scheme")
-    var scheme: String?
-
-    @Option(name: .long, help: "Name of the workspace")
-    var workspace: String?
-    
-    @Option(name: .long, help: "")
-    var resultBundlePath: String?
-        
-    @Flag(help: "Set verbose output")
-    var verbose = false
-    
-    func run() throws {
-        let result: TestResult = try {
-            if let resultBundlePath = resultBundlePath {
-                return try getTestResult(from: resultBundlePath, verbose: verbose)
-            } else if let scheme = scheme {
-                let buildSettings = try getBuildSettings(workspace: workspace, scheme: scheme, verbose: verbose)
-                return try getTestResult(using: buildSettings, verbose: verbose)
-            } else {
-                throw ValidationError("One of arguments `--scheme` or `--result-bundle-path` is required")
-            }
-        }()
-        
-        print(result.lineCoverage)
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            subcommands: [
+                ParseFromProject.self,
+                ParseFromResultBundle.self
+            ],
+            defaultSubcommand: ParseFromProject.self
+        )
     }
 }
 


### PR DESCRIPTION
Current solution relied on fact that project was recently built and we know its xcproject location.

This PR adds possibility to use previously created `xcresult` bundle for coverage parsing.

I did not find any easier solution to parse `Arguments` using _ArgumentParser_ than creating subcommands for parsing from project or from result bundle. To achieve backwards compatibility is the `project` subcommand used by default.